### PR TITLE
iwindow: Forward declare IWindow as a class

### DIFF
--- a/opfor/src/backend/opengl/OpenGLContext.hpp
+++ b/opfor/src/backend/opengl/OpenGLContext.hpp
@@ -6,7 +6,7 @@
 namespace opfor
 {
 
-struct IWindow;
+class IWindow;
 
 class OpenGLContext : public IRendererContext
 {

--- a/opfor/src/opfor/renderer/Context.hpp
+++ b/opfor/src/opfor/renderer/Context.hpp
@@ -1,10 +1,10 @@
 #pragma once
-
 #include "opfor/core/base.hpp"
 
 namespace opfor
 {
-struct IWindow;
+
+class IWindow;
 
 class IRendererContext
 {


### PR DESCRIPTION
Forwarding it as a struct is lying to the interface users and causes
compilation warnings on msvc.

Fixes #17